### PR TITLE
chore: move googleapis as a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-yarn add gsheet-object
+yarn add gsheet-object googleapis
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "prepare": "tsdx build"
   },
   "dependencies": {
-    "debug": "^4.3.1",
-    "dotenv": "^8.2.0",
-    "googleapis": "^45.0.0",
+    "debug": "^4.3.4",
+    "dotenv": "^16.4.5",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21"
+  },
+  "peerDependencies": {
+    "googleapis": ">=45.0.0"
   },
   "husky": {
     "hooks": {
@@ -46,6 +48,7 @@
     "ts-node": "^8.8.2",
     "tsdx": "^0.12.3",
     "tslib": "^1.10.0",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "googleapis": "^45.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,7 +2317,7 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.3.1:
+debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2438,10 +2438,10 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"


### PR DESCRIPTION
To be able to easily update `googleapis` in the parent project.